### PR TITLE
Replaced fallback label from "{{state}}" to empty

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -24,7 +24,7 @@
   "Name": "Home Assistant",
   "Icon": "images/ha-button",
   "URL": "https://github.com/cgiesche/streamdeck-homeassistant",
-  "Version": "1.0",
+  "Version": "1.0.2",
   "OS": [
     {
       "Platform": "mac",

--- a/src/modules/plugin/imageUtils.js
+++ b/src/modules/plugin/imageUtils.js
@@ -218,7 +218,7 @@ const Icon = {
     },
 
     labelledIcon: (state, attributes, templates = {}, image = "", labelTopOffset = 30) => {
-        const line1 = new Handlebars.compile(templates.line1 || "{{state}}")({...{state}, ...attributes, ...{colors}})
+        const line1 = new Handlebars.compile(templates.line1 || "")({...{state}, ...attributes, ...{colors}})
         const line2 = new Handlebars.compile(templates.line2 || "")({...{state}, ...attributes, ...{colors}})
         const line3 = new Handlebars.compile(templates.line3 || "")({...{state}, ...attributes, ...{colors}})
 


### PR DESCRIPTION
Replaced fallback label from "{{state}}" to empty (caused switches to show state as text).
Fixes #1 