### PR TITLE
Set state "1" if result is "playing"

### DIFF
--- a/src/Plugin.vue
+++ b/src/Plugin.vue
@@ -198,6 +198,8 @@ export default {
         if (contextSettings.useStateImagesForOnOffStates) {
           if (stateObject.state === "on") {
             this.$SD.setState(currentContext, 1);
+          } else if (stateObject.state === "playing") {
+            this.$SD.setState(currentContext, 1);
           } else {
             this.$SD.setState(currentContext, 0);
           }


### PR DESCRIPTION
PR to consider a playing `media_player` entity as `on`