### PR TITLE
Add support for more states, such as "active" for timers

### DIFF
--- a/src/Plugin.vue
+++ b/src/Plugin.vue
@@ -197,12 +197,20 @@ export default {
         const buttonImage = this.buttonImageFactory.createButton(entityConfig);
 
         if (contextSettings.useStateImagesForOnOffStates) {
-          if (stateObject.state === "on") {
-            this.$SD.setState(currentContext, 1);
-          } else if (stateObject.state === "playing") {
-            this.$SD.setState(currentContext, 1);
-          } else {
-            this.$SD.setState(currentContext, 0);
+          switch(stateObject.state) {
+            case "on":
+            case "playing":
+            case "open":
+            case "opening":
+            case "home":
+            case "locked":
+            case "active":
+              console.log("Setting state of " + currentContext + " to 1")
+              this.$SD.setState(currentContext, 1);  
+              break;
+            default: 
+              console.log("Setting state of " + currentContext + " to 0")
+              this.$SD.setState(currentContext, 0);
           }
         } else {
           setButtonSVG(buttonImage, currentContext)


### PR DESCRIPTION
This is another partial fix for #88 and a complement of sorts for #95 

This PR adds a bunch more states that would be considered "on" for the custom icons entity. I did this because I have some washer / dryer timer helpers and want to show a green icon when the timer is running without having to make a template sensor in my HA instance.

I've tested it with my timers, and it works great. I haven't tested the others I added (`charging`, `home`, `locked`, `open` and `opening`) because I don't have anything that uses those `device_class`es