### PR TITLE
Send the target for SetImage and SetTitle as a number

### DIFF
--- a/src/modules/common/streamdeck.js
+++ b/src/modules/common/streamdeck.js
@@ -82,7 +82,7 @@ export default class StreamDeck {
             "context": context,
             "payload": {
                 "title": title,
-                "target": ["software", "hardware"]
+                "target": 0,
             }
         }
         this.streamDeckWebsocket.send(JSON.stringify(message))
@@ -94,7 +94,7 @@ export default class StreamDeck {
             "context": context,
             "payload": {
                 "image": image,
-                "target": ["software", "hardware"],
+                "target": 0,
                 "state": 0
             }
         }


### PR DESCRIPTION
The target is a value of 0, 1, or 2 depending on whether it's both, the hardware or the software.

---

This array seems to come from 9b6ca5813ff1f72fbb742a070e255f27ce9565c5 but AFAICT that's never been how the plugin system works. The [documented values](https://developer.elgato.com/documentation/stream-deck/sdk/events-sent/#settitle) are 0,1,2.