### PR TITLE
fix: weather unit

### DIFF
--- a/src/modules/plugin/entityConfigFactory.js
+++ b/src/modules/plugin/entityConfigFactory.js
@@ -303,7 +303,7 @@ export class EntityConfigFactory {
                 if (customizableDefaultConfig.icon) {
                     customizableDefaultConfig.templates.push(" ", " ")
                 }
-                customizableDefaultConfig.templates.push("{{temperature}}{{unit_of_measurement | default('°C')}}", "{{humidity}}%")
+                customizableDefaultConfig.templates.push("{{temperature}}{{temperature_unit | default('°C')}}", "{{humidity}}%")
             }
 
             return customizableDefaultConfig;


### PR DESCRIPTION
Closes #232

The unit_of_measurement was the wrong value, it needs to be temperature_unit to properly display F and C from the home assistant settings