### PR TITLE
Update PiComponent.vue - minor validation change

### DIFF
--- a/src/components/PiComponent.vue
+++ b/src/components/PiComponent.vue
@@ -6,7 +6,7 @@
 
       <div class="mb-3">
         <label class="form-label" for="serverUrl">Server URL</label>
-        <input id="serverUrl" v-model="serverUrl" class="form-control form-control-sm" type="email">
+        <input id="serverUrl" v-model="serverUrl" class="form-control form-control-sm" type="url">
         <div class="form-text"><strong>Without SSL</strong> ws://localhost:8123/api/websocket
         </div>
         <div class="form-text"><strong>With SSL</strong> wss://ha.mydomain.net:8123/api/websocket (requires a trusted


### PR DESCRIPTION
Changed Server URL input validation from 'email' to 'url' - it wasn't a showstopper, but meant the user was presented with a strange message on the tooltip

![image](https://github.com/cgiesche/streamdeck-homeassistant/assets/6720159/6597f172-56b6-4807-8ae0-03674a0c70b3)
