### PR TITLE
Fixed #295: lights without brightness info not working

### DIFF
--- a/public/config/default-display-config.yml
+++ b/public/config/default-display-config.yml
@@ -60,9 +60,10 @@ light:
   color: "#888888"
   feedbackLayout: "$B1"
   feedback: |
+    {% set brightness = attributes.brightness | default(255, true) %}
     {
-      "indicator": {{ attributes.brightness / 255 * 100 }},
-      "value": "{{ (attributes.brightness / 255 * 100) | int }}%"
+      "indicator": {{ brightness / 255 * 100 }},
+      "value": "{{ (brightness / 255 * 100) | int }}%"
     }
   states:
     unavailable:


### PR DESCRIPTION
Fixed #295: Set default brightness to 255 if state attributes do not contain brightness.