### PR TITLE
Fix rotationPercent settings from entity config

### DIFF
--- a/src/modules/plugin/entityConfigFactoryNg.js
+++ b/src/modules/plugin/entityConfigFactoryNg.js
@@ -74,10 +74,12 @@ export class EntityConfigFactory {
     const iconString = this.resolve('icon', resolvers)
     const colorString = this.resolve('color', resolvers)
     const labelTemplates = this.resolve('labelTemplates', resolvers)
+    const rotationPercentString = this.resolve('rotationPercent', resolvers)
 
     const feedbackLayout= this.render(feedbackLayoutString, stateObject)
     const renderedFeedback = this.render(feedbackValueString, stateObject)
     const feedback = feedbackValueString ? JSON.parse(renderedFeedback) : {}
+    const rotationPercent = rotationPercentString ? +this.render(rotationPercentString, stateObject) : undefined
 
     const icon = this.render(iconString, stateObject)
     const color = this.render(colorString, stateObject)
@@ -87,7 +89,8 @@ export class EntityConfigFactory {
       feedback: feedback,
       icon: icon,
       color: color,
-      labelTemplates: labelTemplates
+      labelTemplates: labelTemplates,
+      rotationPercent
     }
   }
 


### PR DESCRIPTION
The plugin code supports updating rotation percentage using value calculated from the entity config yaml, but the config factory does not pass this field along, so it does not work. This PR fixes the issue.