### PR TITLE
Fix shell command names display by using technical service name when human-readable name is empty

### DIFF
--- a/src/modules/homeassistant/homeassistant.js
+++ b/src/modules/homeassistant/homeassistant.js
@@ -39,7 +39,11 @@ export class Homeassistant {
           throw messageData.error.message
         }
         if (this.requests.has(messageData.id)) {
-          this.requests.get(messageData.id)(messageData.result)
+          let result = messageData.result.map(state => ({
+            ...state,
+            name: state.attributes.friendly_name || state.entity_id
+          }))
+          this.requests.get(messageData.id)(result)
         }
         break
       case 'event':


### PR DESCRIPTION
### Summary
This PR fixes the issue where shell command names were not displayed correctly in the Home Assistant plugin. When the human-readable name (`friendly_name`) is empty, the technical service name (`entity_id`) is now used as a fallback.

### Changes
Updated `homeassistant.js` to map the `name` field to `friendly_name` or `entity_id` if `friendly_name` is empty.

### Related Issues
Fixes #327

### Notes
Please review the changes and let me know if any adjustments are needed.