### PR TITLE
Add media player play/pause/stop icons

### DIFF
--- a/public/config/default-display-config.yml
+++ b/public/config/default-display-config.yml
@@ -326,3 +326,25 @@ fan:
   states:
     off:
       icon: mdi:fan-off
+
+media_player:
+  icon: mdi:play-circle
+  color: '#AAAAAA'
+  labelTemplates:
+    - ''
+    - ''
+    - '{{ media_title }}'
+    - '{{ media_artist}}'
+  states:
+    playing:
+      color: '#00C937'
+      icon: mdi:play
+    paused:
+      color: '#F9F871'
+      icon: mdi:pause
+    idle:
+      color: '#505050'
+      icon: mdi:stop
+    off:
+      color: '#505050'
+      icon: mdi:television-off


### PR DESCRIPTION
Adds a display configuration for media_player devices with play/pause based on current state. (Was going to try for https://github.com/cgiesche/streamdeck-homeassistant/discussions/213 but that looks a little more involved - would probably need e.g. a background template field to get the {{ entity_picture }} value and render it. But I figure play/pause is good enough while I'm being lazy ;) )