### PR TITLE
Light brightness sync for encoder dial

### DIFF
--- a/public/config/default-display-config.yml
+++ b/public/config/default-display-config.yml
@@ -68,6 +68,10 @@ light:
   icon: mdi:lightbulb
   color: '#888888'
   feedbackLayout: '$B1'
+  rotationPercent: |
+    {% set defaultBrightness = (255 if state === 'on' else 0) %}
+    {% set brightness = attributes.brightness | default(defaultBrightness, true) %}
+    {{ brightness / 255 * 100 }}
   feedback: |
     {% set defaultBrightness = (255 if state === 'on' else 0) %}
     {% set brightness = attributes.brightness | default(defaultBrightness, true) %}

--- a/src/components/PluginComponent.vue
+++ b/src/components/PluginComponent.vue
@@ -61,6 +61,9 @@ onMounted(async () => {
       rotationAmount[context] = 0
       rotationPercent[context] = 0
       actionSettings.value[context] = Settings.parse(message.payload.settings)
+      if (message.payload.controller) {
+        actionSettings.value[context].controllerType = message.payload.controller
+      }
       if ($HA.value) {
         $HA.value.getStatesDebounced(entityStatesChanged)
       }

--- a/src/modules/plugin/entityConfigFactoryNg.js
+++ b/src/modules/plugin/entityConfigFactoryNg.js
@@ -76,6 +76,7 @@ export class EntityConfigFactory {
     const iconString = this.resolve('icon', resolvers)
     const colorString = this.resolve('color', resolvers)
     const labelTemplates = this.resolve('labelTemplates', resolvers)
+    const rotationPercentString = this.resolve('rotationPercent', resolvers)
 
     const feedbackLayout = this.render(feedbackLayoutString, stateObject)
     const renderedFeedback = this.render(feedbackValueString, stateObject)
@@ -83,13 +84,18 @@ export class EntityConfigFactory {
 
     const icon = this.render(iconString, stateObject)
     const color = this.render(colorString, stateObject)
+    const rotationPercent =
+      rotationPercentString !== undefined
+        ? parseFloat(this.render(rotationPercentString, stateObject))
+        : undefined
 
     return {
       feedbackLayout: feedbackLayout,
       feedback: feedback,
       icon: icon,
       color: color,
-      labelTemplates: labelTemplates
+      labelTemplates: labelTemplates,
+      rotationPercent: rotationPercent
     }
   }
 


### PR DESCRIPTION
## Summary

- **`entityConfigFactoryNg.js`**: Added support for a `rotationPercent` field in display config YAML. The factory now resolves, renders (Nunjucks), and returns it as a float in `renderingConfig`, enabling display configs to define how the dial position maps to entity state.

- **`default-display-config.yml`**: Added `rotationPercent` template for the `light` domain — syncs the encoder dial position to the actual HA brightness (`attributes.brightness / 255 * 100`). When a state update arrives from HA, the dial automatically reflects the real brightness, so subsequent rotations start from the correct position instead of from 0.

- **`PluginComponent.vue`**: Fixed a bug where encoder buttons always had `controllerType: 'Keypad'` until the Property Inspector was opened at least once. The `willAppear` event payload already contains `controller: "Encoder"` from the StreamDeck SDK — we now use it to override the setting immediately, so `setFeedback()` is called correctly from the first state update.

## Usage (Rotation service call)

| Field | Value |
|-------|-------|
| Service | `light.turn_on` |
| Entity | `light.your_light` |
| Service Data | `{"brightness": "{{ rotationAbsolute \| int }}"}` |

`rotationAbsolute` is 0–255, matching HA's `brightness` parameter directly.

## Test plan

- [ ] Add an encoder button on a StreamDeck Plus for a dimmable light entity
- [ ] Confirm the brightness indicator updates on the dial display when HA state changes
- [ ] Rotate dial and confirm brightness changes correctly in HA
- [ ] Confirm the dial display shows correct brightness immediately on plugin start (before opening PI)
- [ ] Change brightness from another HA client — confirm dial syncs to new value

🤖 Generated with [Claude Code](https://claude.com/claude-code)