### PR TITLE
Add configurable label font size

### DIFF
--- a/src/components/PiComponent.vue
+++ b/src/components/PiComponent.vue
@@ -173,19 +173,18 @@
       </div>
 
       <template v-if="controllerType !== 'Encoder'">
-        <div class="mb-3">
-          <label class="form-label" for="labelFontSize"
-            >Label font size ({{ labelFontSize }}px)</label
-          >
-          <input
+        <div class="d-flex align-items-center mb-2">
+          <label class="form-label mb-0 me-2 text-nowrap" for="labelFontSize">Label font size</label>
+          <select
             id="labelFontSize"
             v-model.number="labelFontSize"
-            class="form-range"
-            max="96"
-            min="16"
-            step="2"
-            type="range"
-          />
+            class="form-select form-select-sm"
+            style="width: auto"
+          >
+            <option v-for="size in [24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64, 72, 80, 96]" :key="size" :value="size">
+              {{ size }}px
+            </option>
+          </select>
         </div>
 
         <div class="form-check form-switch">

--- a/src/components/PiComponent.vue
+++ b/src/components/PiComponent.vue
@@ -173,6 +173,21 @@
       </div>
 
       <template v-if="controllerType !== 'Encoder'">
+        <div class="mb-3">
+          <label class="form-label" for="labelFontSize"
+            >Label font size ({{ labelFontSize }}px)</label
+          >
+          <input
+            id="labelFontSize"
+            v-model.number="labelFontSize"
+            class="form-range"
+            max="96"
+            min="16"
+            step="2"
+            type="range"
+          />
+        </div>
+
         <div class="form-check form-switch">
           <input
             id="chkEnableServiceIndicator"
@@ -363,6 +378,7 @@ const buttonTitle = ref('{{friendly_name}}')
 const useStateImagesForOnOffStates = ref(false) // determined by action ID (manifest)
 const useCustomButtonLabels = ref(false)
 const buttonLabels = ref('')
+const labelFontSize = ref(48)
 const enableServiceIndicator = ref(true)
 const iconSettings = ref('PREFER_PLUGIN')
 const availableEntityDomains = ref([])
@@ -422,6 +438,7 @@ onMounted(() => {
       enableServiceIndicator.value =
         settings['display']['enableServiceIndicator'] ||
         settings['display']['enableServiceIndicator'] === undefined
+      labelFontSize.value = settings['display']['labelFontSize'] || 48
       iconSettings.value = settings['display']['iconSettings']
       useCustomTitle.value = settings['display']['useCustomTitle']
       buttonTitle.value = settings['display']['buttonTitle'] || '{{friendly_name}}'
@@ -556,7 +573,7 @@ function saveGlobalSettings() {
 
 function saveSettings() {
   let settings = {
-    version: 5,
+    version: 6,
 
     controllerType: controllerType.value,
 
@@ -565,6 +582,7 @@ function saveSettings() {
       useCustomTitle: useCustomTitle.value,
       buttonTitle: buttonTitle.value,
       enableServiceIndicator: enableServiceIndicator.value,
+      labelFontSize: labelFontSize.value,
       iconSettings: iconSettings.value,
       useCustomButtonLabels: useCustomButtonLabels.value,
       buttonLabels: buttonLabels.value,

--- a/src/components/PluginComponent.vue
+++ b/src/components/PluginComponent.vue
@@ -318,6 +318,7 @@ function updateContextState(currentContext, domain, stateObject) {
           : entityConfigFactory.colors.neutral
     }
 
+    renderingConfig.fontSize = contextSettings.display.labelFontSize
     const buttonSVG = svgUtils.renderButtonSVG(renderingConfig, stateObject)
     setButtonSVG(buttonSVG, currentContext)
   }

--- a/src/modules/common/settings.js
+++ b/src/modules/common/settings.js
@@ -119,6 +119,15 @@ export class Settings {
     }
 
     if (settings.version === 5) {
+      let settingsV6 = { ...settings }
+      settingsV6.version = 6
+
+      settingsV6.display.labelFontSize = 48
+
+      return this.parse(settingsV6)
+    }
+
+    if (settings.version === 6) {
       return settings
     }
   }

--- a/src/modules/plugin/svgUtils.js
+++ b/src/modules/plugin/svgUtils.js
@@ -30,12 +30,14 @@ export class SvgUtils {
       ...stateObject.attributes,
       ...{ state: stateObject.state }
     })
+    const fontSize = renderingConfig.fontSize || this.fontSize
     return this.#generateButtonSVG(
       buttonLabels,
       renderingConfig.icon,
       renderingConfig.color,
       renderingConfig.isAction,
-      renderingConfig.isMultiAction
+      renderingConfig.isMultiAction,
+      fontSize
     )
   }
 
@@ -76,7 +78,7 @@ export class SvgUtils {
     return outerSVG
   }
 
-  #generateButtonSVG(labels, mdiIconName, iconColor, isAction = false, isMultiAction = false) {
+  #generateButtonSVG(labels, mdiIconName, iconColor, isAction = false, isMultiAction = false, fontSize = this.fontSize) {
     let iconData = null
     if (mdiIconName) {
       iconData = Mdi[this.#toPascalCase(mdiIconName)]
@@ -105,7 +107,7 @@ export class SvgUtils {
     for (let i = 0; i < labels.length; i++) {
       let lines = labels[i].split('\n')
       for (let i = currentLineNumber; i < lines.length + currentLineNumber; i++) {
-        this.#drawText(lines[i - currentLineNumber], i)
+        this.#drawText(lines[i - currentLineNumber], i, fontSize)
       }
       currentLineNumber += lines.length
     }
@@ -123,16 +125,17 @@ export class SvgUtils {
     return outerSVG
   }
 
-  #drawText(text, lineNr) {
+  #drawText(text, lineNr, fontSize = this.fontSize) {
     const escapedText = urlencode(text)
     const quarterHeight = this.buttonRes.height / 4
+    const attr = { ...this.lineAttr, 'font-size': `${fontSize}px` }
     this.snap
       .text(
         0,
-        quarterHeight - (quarterHeight * 1.2 - this.fontSize) / 2 + lineNr * quarterHeight,
+        quarterHeight - (quarterHeight * 1.2 - fontSize) / 2 + lineNr * quarterHeight,
         escapedText
       )
-      .attr(this.lineAttr)
+      .attr(attr)
       .transform(`translateX(${this.halfRes.width})`)
   }
 

--- a/src/vite/RestartStreamDeck.js
+++ b/src/vite/RestartStreamDeck.js
@@ -5,7 +5,7 @@ export default function RestartStreamDeck() {
     name: 'streamdeck-restart-once',
     apply: 'build',
     closeBundle() {
-      exec('streamdeck restart de.perdoctus.streamdeck.homeassistant', (err, stdout, stderr) => {
+      exec('streamdeck restart de.perdoctus.streamdeck.homeassistant', (err, stdout) => {
         if (err) {
           console.warn('Stream Deck restart failed. Ensure the Elgato Stream Deck app and CLI are installed and accessible.')
         } else {


### PR DESCRIPTION
  ## Summary

     This PR adds support for configuring the font size used for custom labels on Stream Deck buttons.

     ## Changes

     - add a font size slider to the property inspector for non-encoder buttons
     - store the selected value in `display.labelFontSize`
     - pass the configured font size into SVG label rendering
     - migrate older settings to version 6 with a default `labelFontSize` of `48`
    
<img width="897" height="319" alt="5a096296-9fbe-4d96-be2d-caff4554f169" src="https://github.com/user-attachments/assets/0a17c556-ac62-401b-93b2-fac611c7a555" />
<img width="860" height="328" alt="7b9aaf1d-10f3-4f84-8dc8-e6fb8e2cea41" src="https://github.com/user-attachments/assets/3a917c0a-2eb0-4de1-88f9-e01a94ef3301" />


