### PR TITLE
feat: add backgroundColor support to custom display configuration

### DIFF
--- a/src/modules/plugin/entityConfigFactoryNg.js
+++ b/src/modules/plugin/entityConfigFactoryNg.js
@@ -75,6 +75,7 @@ export class EntityConfigFactory {
     const feedbackValueString = this.resolve('feedback', resolvers)
     const iconString = this.resolve('icon', resolvers)
     const colorString = this.resolve('color', resolvers)
+    const backgroundColorString = this.resolve('backgroundColor', resolvers)
     const labelTemplates = this.resolve('labelTemplates', resolvers)
 
     const feedbackLayout = this.render(feedbackLayoutString, stateObject)
@@ -83,12 +84,14 @@ export class EntityConfigFactory {
 
     const icon = this.render(iconString, stateObject)
     const color = this.render(colorString, stateObject)
+    const backgroundColor = this.render(backgroundColorString, stateObject)
 
     return {
       feedbackLayout: feedbackLayout,
       feedback: feedback,
       icon: icon,
       color: color,
+      backgroundColor: backgroundColor,
       labelTemplates: labelTemplates
     }
   }
@@ -99,6 +102,7 @@ export class EntityConfigFactory {
     const defaultConfig = {}
     if (config._icon) defaultConfig.icon = config._icon
     if (config._color) defaultConfig.color = config._color
+    if (config._backgroundColor) defaultConfig.backgroundColor = config._backgroundColor
     if (config._labelTemplates) defaultConfig.labelTemplates = config._labelTemplates
     resolvers.push(defaultConfig)
 

--- a/src/modules/plugin/svgUtils.js
+++ b/src/modules/plugin/svgUtils.js
@@ -35,7 +35,8 @@ export class SvgUtils {
       renderingConfig.icon,
       renderingConfig.color,
       renderingConfig.isAction,
-      renderingConfig.isMultiAction
+      renderingConfig.isMultiAction,
+      renderingConfig.backgroundColor
     )
   }
 
@@ -76,7 +77,11 @@ export class SvgUtils {
     return outerSVG
   }
 
-  #generateButtonSVG(labels, mdiIconName, iconColor, isAction = false, isMultiAction = false) {
+  #generateButtonSVG(labels, mdiIconName, iconColor, isAction = false, isMultiAction = false, backgroundColor = null) {
+    if (backgroundColor) {
+      this.snap.rect(0, 0, this.buttonRes.width, this.buttonRes.height).attr('fill', backgroundColor)
+    }
+
     let iconData = null
     if (mdiIconName) {
       iconData = Mdi[this.#toPascalCase(mdiIconName)]


### PR DESCRIPTION
Allows setting dynamic background colors per domain, state, or device class in custom display YAML configs, using the same cascading resolution and Nunjucks templating as the existing color property.