### PR TITLE
fixes #398: execute_script + retain `rotationPercent` across context reinitializations

### DIFF
--- a/src/components/PluginComponent.vue
+++ b/src/components/PluginComponent.vue
@@ -119,7 +119,11 @@ onMounted(async () => {
     $SD.value.on('willAppear', (message) => {
       let context = message.context
       rotationAmount[context] = 0
-      rotationPercent[context] = 0
+      // Keep accumulated rotationPercent across page changes (willAppear fires
+      // on every page switch for the same context); only initialise once.
+      if (rotationPercent[context] === undefined) {
+        rotationPercent[context] = 0
+      }
       actionSettings.value[context] = Settings.parse(message.payload.settings)
       if ($HA.value) {
         $HA.value.getStatesDebounced(entityStatesChanged)
@@ -186,7 +190,9 @@ onMounted(async () => {
     $SD.value.on('didReceiveSettings', (message) => {
       let context = message.context
       rotationAmount[context] = 0
-      rotationPercent[context] = 0
+      if (rotationPercent[context] === undefined) {
+        rotationPercent[context] = 0
+      }
       actionSettings.value[context] = Settings.parse(message.payload.settings)
       if ($HA.value) {
         $HA.value.getStatesDebounced(entityStatesChanged)

--- a/src/modules/homeassistant/homeassistant.js
+++ b/src/modules/homeassistant/homeassistant.js
@@ -1,7 +1,6 @@
 import {
   createConnection,
   createLongLivedTokenAuth,
-  callService as haCallService,
   ERR_CANNOT_CONNECT,
   ERR_INVALID_AUTH,
   ERR_CONNECTION_LOST,
@@ -100,7 +99,19 @@ export class Homeassistant {
     if (!this._connection) {
       return Promise.reject(new Error('Not connected to Home Assistant'))
     }
-    const target = entity_id ? { entity_id } : undefined
-    return haCallService(this._connection, domain, service, serviceData, target)
+    // Use execute_script (not call_service) so HA renders Jinja templates in
+    // serviceData server-side, e.g. {{ state_attr(...) }}. The plain
+    // call_service WS API does not template service data.
+    const step = {
+      service: `${domain}.${service}`,
+      data: serviceData || {}
+    }
+    if (entity_id) {
+      step.target = { entity_id }
+    }
+    return this._connection.sendMessagePromise({
+      type: 'execute_script',
+      sequence: [step]
+    })
   }
 }


### PR DESCRIPTION
- Prevent `rotationPercent` from resetting during page switches by initializing only when undefined.
- Replace `callService` with `execute_script` in Home Assistant integration to support server side Jinja template rendering in `serviceData`.