### PR TITLE
fix(ha): skip invalid entity IDs instead of failing all subscriptions

### DIFF
--- a/src/modules/homeassistant/homeassistant.js
+++ b/src/modules/homeassistant/homeassistant.js
@@ -84,15 +84,38 @@ export class Homeassistant {
     this._connection.sendMessagePromise({ type: 'get_services' }).then(callback)
   }
 
-  subscribeEntitiesChanged(entityIds, callback) {
-    if (!this._connection) return Promise.resolve(null)
-    return this._connection.subscribeMessage(callback, {
-      type: 'subscribe_trigger',
-      trigger: {
-        platform: 'state',
-        entity_id: entityIds
+  async subscribeEntitiesChanged(entityIds, callback) {
+    if (!this._connection) return null
+    try {
+      return await this._connection.subscribeMessage(callback, {
+        type: 'subscribe_trigger',
+        trigger: {
+          platform: 'state',
+          entity_id: entityIds
+        }
+      })
+    } catch (e) {
+      if (e?.code !== 'invalid_format' || entityIds.length <= 1) throw e
+      // Batch rejected due to one or more invalid entity IDs — retry one-by-one so
+      // a single misconfigured button doesn't break live updates for all others.
+      console.warn('subscribe_trigger batch failed with invalid_format; retrying per entity')
+      const unsubscribers = []
+      for (const entityId of entityIds) {
+        try {
+          const unsub = await this._connection.subscribeMessage(callback, {
+            type: 'subscribe_trigger',
+            trigger: { platform: 'state', entity_id: entityId }
+          })
+          unsubscribers.push(unsub)
+        } catch {
+          console.warn(`Skipping invalid entity "${entityId}" — check its configuration in Stream Deck`)
+        }
       }
-    })
+      if (unsubscribers.length === 0) throw e
+      return async () => {
+        await Promise.all(unsubscribers.map((u) => u().catch(() => {})))
+      }
+    }
   }
 
   callService(domain, service, entity_id = null, serviceData = {}) {


### PR DESCRIPTION
## Root cause

When `subscribe_trigger` is called with a batch of entity IDs and **one of them is invalid**, Home Assistant rejects the entire request with `{ code: "invalid_format" }`. This silently kills live updates for **all** buttons, not just the misconfigured one — which is why users see states refresh on Save (via `get_states`) but never update live.

This is a different root cause than the admin/permissions explanation in the existing thread. Confirmed via developer tools: the error object is `{ code: "invalid_format", message: "Entity <id> ..." }`, not an auth error.

## Fix

On `invalid_format` with multiple entity IDs, retry `subscribe_trigger` one entity at a time and skip any that HA rejects with a console warning. Valid entities continue to receive live updates; the bad one is skipped until the user fixes its configuration in Stream Deck.

If every individual subscription also fails (e.g. genuine permissions issue), the original error is re-thrown so existing error handling is unchanged.

## Behaviour

- **Admin token, all valid entity IDs**: unchanged — single batch subscription as before
- **Admin token, one invalid entity ID**: batch fails → retry per entity → bad one skipped with warning, all others get live updates
- **Non-admin token**: `subscribe_trigger` throws a non-`invalid_format` error → re-thrown → existing error handling takes over

Closes #404