### PR TITLE
feat(encoder): allow per-dial progress bar override

### DIFF
--- a/src/components/PiComponent.vue
+++ b/src/components/PiComponent.vue
@@ -309,6 +309,41 @@
           </details>
         </PiToggleRow>
 
+        <!-- Progress bar overrides (Encoder / dial only) -->
+        <template v-if="controllerType === 'Encoder'">
+          <PiToggleRow id="chkCustomIndicator" v-model="useCustomIndicator" label="Custom progress bar">
+            <input
+              id="customIndicator"
+              v-model="customIndicator"
+              class="pi-input mb-1"
+              placeholder="Template resolving to a number 0-100"
+              type="text"
+            />
+            <div class="pi-hint">
+              Overrides the dial's progress bar. Must resolve to 0-100. Use entity
+              attributes (e.g. color_temp_kelvin) so two dials on the same entity can
+              show different bars.
+            </div>
+            <details v-if="entityAttributes.length" class="pi-vars">
+              <summary>Available variables</summary>
+              <div class="pi-vars-content">
+                <div v-for="attr in entityAttributes" :key="attr" class="pi-var-item">
+                  {{ attr }}
+                </div>
+              </div>
+            </details>
+          </PiToggleRow>
+
+          <div class="mb-3">
+            <label class="pi-label" for="feedbackLayoutOverride">Progress bar layout</label>
+            <select id="feedbackLayoutOverride" v-model="feedbackLayoutOverride" class="pi-select">
+              <option value="">Theme default</option>
+              <option value="$B1">Show bar</option>
+              <option value="$A1">Hide bar</option>
+            </select>
+          </div>
+        </template>
+
         <!-- Label font size -->
         <div class="pi-form-row">
           <div style="display: flex; align-items: center; gap: 6px; margin-bottom: 4px">
@@ -476,6 +511,9 @@ const buttonTitle = ref('{{friendly_name}}')
 const useStateImagesForOnOffStates = ref(false) // determined by action ID (manifest)
 const useCustomButtonLabels = ref(false)
 const buttonLabels = ref('')
+const useCustomIndicator = ref(false)
+const customIndicator = ref('')
+const feedbackLayoutOverride = ref('')
 const enableServiceIndicator = ref(true)
 const iconSettings = ref('PREFER_PLUGIN')
 const iconLayout = ref('STANDARD')
@@ -559,6 +597,9 @@ onMounted(() => {
       buttonTitle.value = settings['display']['buttonTitle'] || '{{friendly_name}}'
       useCustomButtonLabels.value = settings['display']['useCustomButtonLabels']
       buttonLabels.value = settings['display']['buttonLabels']
+      useCustomIndicator.value = settings['display']['useCustomIndicator'] || false
+      customIndicator.value = settings['display']['customIndicator'] || ''
+      feedbackLayoutOverride.value = settings['display']['feedbackLayoutOverride'] || ''
       serviceShortPress.value = settings['button']['serviceShortPress']
       serviceLongPress.value = settings['button']['serviceLongPress']
       serviceTap.value = settings['button']['serviceTap']
@@ -718,6 +759,9 @@ function saveSettings() {
       backgroundColorEnd: bgColorEnd,
       useCustomButtonLabels: useCustomButtonLabels.value,
       buttonLabels: buttonLabels.value,
+      useCustomIndicator: useCustomIndicator.value,
+      customIndicator: customIndicator.value,
+      feedbackLayoutOverride: feedbackLayoutOverride.value,
       useStateImagesForOnOffStates: useStateImagesForOnOffStates.value // determined by action ID (manifest)
     },
 

--- a/src/components/PluginComponent.vue
+++ b/src/components/PluginComponent.vue
@@ -416,6 +416,10 @@ async function updateContextState(currentContext, domain, stateObject, generatio
     if (!renderingConfig.feedbackLayout) {
       renderingConfig.feedbackLayout = '$A1'
     }
+    // Per-dial layout override (e.g. '$A1' to hide the progress bar) wins over the theme.
+    if (contextSettings.display.feedbackLayoutOverride) {
+      renderingConfig.feedbackLayout = contextSettings.display.feedbackLayoutOverride
+    }
     $SD.value.setFeedbackLayout(currentContext, { layout: renderingConfig.feedbackLayout })
 
     if (!renderingConfig.feedback) {
@@ -429,6 +433,19 @@ async function updateContextState(currentContext, domain, stateObject, generatio
           state: stateObject.state
         })
         .join(' ')
+    }
+    // Per-dial progress-bar value override: lets two dials on the same entity show
+    // different bars (e.g. brightness vs. color temp). Falls back to the theme's
+    // indicator when disabled or when the template doesn't yield a number.
+    if (contextSettings.display.useCustomIndicator) {
+      const rendered = svgUtils.renderTemplates([contextSettings.display.customIndicator], {
+        ...stateObject.attributes,
+        state: stateObject.state
+      })[0]
+      const indicator = Number(rendered)
+      if (!Number.isNaN(indicator)) {
+        renderingConfig.feedback.indicator = Math.max(0, Math.min(100, indicator))
+      }
     }
     renderingConfig.feedback.icon = await svgUtils.svgToImageDataUri(
       svgUtils.renderButtonSVG({ ...renderingConfig, labelTemplates: [] }, stateObject),

--- a/src/modules/common/settings.js
+++ b/src/modules/common/settings.js
@@ -1,6 +1,6 @@
 import { trimBlankLabelLines } from './labelLines.js'
 
-export const CURRENT_VERSION = 8
+export const CURRENT_VERSION = 9
 export const DEFAULT_LABEL_FONT_SIZE = 48
 
 function migrateV1(s) {
@@ -87,6 +87,16 @@ function migrateV7(s) {
   return v8
 }
 
+function migrateV8(s) {
+  const v9 = { ...s, display: { ...s.display }, version: 9 }
+  // Per-dial (Encoder) progress-bar overrides. Empty/false means "use the theme
+  // default", so existing dials are unchanged.
+  v9.display.useCustomIndicator = false
+  v9.display.customIndicator = ''
+  v9.display.feedbackLayoutOverride = ''
+  return v9
+}
+
 const MIGRATIONS = {
   1: migrateV1,
   2: migrateV2,
@@ -94,7 +104,8 @@ const MIGRATIONS = {
   4: migrateV4,
   5: migrateV5,
   6: migrateV6,
-  7: migrateV7
+  7: migrateV7,
+  8: migrateV8
 }
 
 export class Settings {

--- a/src/modules/common/settings.migrate-indicator.test.js
+++ b/src/modules/common/settings.migrate-indicator.test.js
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { Settings, CURRENT_VERSION } from './settings.js'
+
+describe('Settings.parse v8 -> v9 per-dial indicator migration', () => {
+  it('adds the new indicator/layout display defaults', () => {
+    const parsed = Settings.parse({ version: 8, display: {}, button: {} })
+    expect(parsed.version).toBe(CURRENT_VERSION)
+    expect(parsed.display.useCustomIndicator).toBe(false)
+    expect(parsed.display.customIndicator).toBe('')
+    expect(parsed.display.feedbackLayoutOverride).toBe('')
+  })
+
+  it('preserves existing display fields while adding the new ones', () => {
+    const parsed = Settings.parse({
+      version: 8,
+      display: { entityId: 'light.den', backgroundColor: '#123456' },
+      button: {}
+    })
+    expect(parsed.display.entityId).toBe('light.den')
+    expect(parsed.display.backgroundColor).toBe('#123456')
+    expect(parsed.display.useCustomIndicator).toBe(false)
+  })
+
+  it('carries a v1 config all the way to v9 with the new fields present', () => {
+    const parsed = Settings.parse({ version: 1, entityId: 'light.den' })
+    expect(parsed.version).toBe(CURRENT_VERSION)
+    expect(parsed.display).toHaveProperty('useCustomIndicator', false)
+    expect(parsed.display).toHaveProperty('customIndicator', '')
+    expect(parsed.display).toHaveProperty('feedbackLayoutOverride', '')
+  })
+})


### PR DESCRIPTION
Implements #416 

Dial feedback (indicator + layout) was driven solely by the per-domain theme template, rendered with only the entity state, so two dials on the same entity shared one progress bar. Title and value already supported per-dial overrides; the indicator and layout did not.

Add optional per-dial display settings, applied in the encoder render branch:
- useCustomIndicator + customIndicator: a Nunjucks template (0-100) that overrides feedback.indicator, letting two dials on one entity show different bars (e.g. brightness vs. color temperature).
- feedbackLayoutOverride: overrides the feedback layout per dial (e.g. $A1 to hide the bar).

Dials without these settings keep the existing theme-driven behavior. Adds a v8->v9 settings migration seeding the new fields, Property Inspector controls for both, and a migration test.