### PR TITLE
Configurable on/off/offline icons for the "Entity (custom icons)" action

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -51,7 +51,7 @@
   "Name": "Home Assistant",
   "Icon": "images/plugin/plugin",
   "URL": "https://github.com/cgiesche/streamdeck-homeassistant",
-  "Version": "100.2.1.1",
+  "Version": "100.2.1.3",
   "OS": [
     {
       "Platform": "mac",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -51,7 +51,7 @@
   "Name": "Home Assistant",
   "Icon": "images/plugin/plugin",
   "URL": "https://github.com/cgiesche/streamdeck-homeassistant",
-  "Version": "100.2.1.3",
+  "Version": "100.3.0.0",
   "OS": [
     {
       "Platform": "mac",

--- a/src/components/PiComponent.vue
+++ b/src/components/PiComponent.vue
@@ -170,6 +170,60 @@
         <label class="pi-label">Entity</label>
         <TypeaheadSelect v-model="entity" class="mb-3" :items="entityItems" placeholder="No entity selected" />
 
+        <!-- Custom state icons (custom-icons action only) -->
+        <div v-if="useStateImagesForOnOffStates" class="mb-3">
+          <label class="pi-label">Custom icons</label>
+          <div class="pi-icon-row">
+            <div v-for="slot in CUSTOM_ICON_SLOTS" :key="slot.key" class="pi-icon-slot">
+              <button
+                type="button"
+                class="pi-icon-tile"
+                :class="{
+                  'pi-icon-tile-set': customIcons[slot.key],
+                  'pi-icon-tile-drag': dragOverSlot === slot.key
+                }"
+                :title="`Choose ${slot.label.toLowerCase()} image (click or drop a file)`"
+                @click="pickCustomIcon(slot.key)"
+                @dragover.prevent
+                @dragenter.prevent="dragOverSlot = slot.key"
+                @dragleave="onIconDragLeave(slot.key)"
+                @drop.prevent="onCustomIconDropped(slot.key, $event)"
+              >
+                <img v-if="customIcons[slot.key]" :src="customIcons[slot.key]" :alt="slot.label" />
+                <span v-else class="pi-icon-plus">+</span>
+              </button>
+              <button
+                v-if="customIcons[slot.key]"
+                type="button"
+                class="pi-icon-remove"
+                title="Remove"
+                @click="clearCustomIcon(slot.key)"
+              >
+                ×
+              </button>
+              <div class="pi-icon-label">{{ slot.label }}</div>
+            </div>
+          </div>
+          <input
+            ref="customIconFileInput"
+            type="file"
+            accept="image/*"
+            style="display: none"
+            @change="onCustomIconSelected($event)"
+          />
+          <div v-if="customIconError" class="pi-hint" style="color: var(--pi-warning)">
+            {{ customIconError }}
+          </div>
+          <div class="pi-hint" style="color: var(--pi-warning)">
+            Icons dragged directly onto the key in Stream Deck override these. Reset the key
+            images to default (arrow menu on the key preview) for icons set here to show.
+          </div>
+          <div class="pi-hint">
+            Offline is shown when the entity is unavailable or unknown; if not set, the off icon
+            is used. Remember to save your settings below.
+          </div>
+        </div>
+
         <!-- Icon source radio group -->
         <div class="mb-3">
           <label class="pi-label">Icon source</label>
@@ -455,7 +509,12 @@ import {
 import { Homeassistant } from '@/modules/homeassistant/homeassistant'
 import { Entity } from '@/modules/pi/entity'
 import { Service } from '@/modules/pi/service'
-import { computed, onMounted, ref, watch } from 'vue'
+import {
+  fileUrlFromDataTransfer,
+  fileUrlFromInputValue,
+  loadIconAsDataUri
+} from '@/modules/pi/iconLoader'
+import { computed, onMounted, reactive, ref, watch } from 'vue'
 import ServiceCallConfiguration from '@/components/ServiceCallConfiguration.vue'
 import { ObjectUtils } from '@/modules/common/utils'
 import TypeaheadSelect from '@/components/ui/TypeaheadSelect.vue'
@@ -490,6 +549,20 @@ const rotationTickBucketSizeMs = ref(300)
 const useCustomTitle = ref(false)
 const buttonTitle = ref('{{friendly_name}}')
 const useStateImagesForOnOffStates = ref(false) // determined by action ID (manifest)
+// Plugin-rendered state icons (data URIs); key images set in the Stream
+// Deck UI take priority over these.
+const CUSTOM_ICON_SLOTS = [
+  { key: 'off', label: 'Off' },
+  { key: 'on', label: 'On' },
+  { key: 'offline', label: 'Offline' }
+]
+const customIcons = reactive({ on: '', off: '', offline: '' })
+const customIconError = ref('')
+const customIconFileInput = ref(null)
+// Slot the hidden file input is currently picking for.
+let pendingIconSlot = null
+// Slot currently hovered by a drag, for the drop highlight.
+const dragOverSlot = ref(null)
 const useCustomButtonLabels = ref(false)
 const buttonLabels = ref('')
 const enableServiceIndicator = ref(true)
@@ -515,6 +588,11 @@ const controllerType = ref('')
 
 onMounted(() => {
   updateManifest()
+
+  // A file dropped outside the icon tiles would otherwise navigate the
+  // inspector page to the dropped file.
+  window.addEventListener('dragover', (e) => e.preventDefault())
+  window.addEventListener('drop', (e) => e.preventDefault())
 
   window.connectElgatoStreamDeckSocket = (
     inPort,
@@ -578,6 +656,9 @@ onMounted(() => {
       buttonTitle.value = settings['display']['buttonTitle'] || '{{friendly_name}}'
       useCustomButtonLabels.value = settings['display']['useCustomButtonLabels']
       buttonLabels.value = settings['display']['buttonLabels']
+      customIcons.on = settings['display']['onIcon'] ?? ''
+      customIcons.off = settings['display']['offIcon'] ?? ''
+      customIcons.offline = settings['display']['offlineIcon'] ?? ''
       serviceShortPress.value = settings['button']['serviceShortPress']
       serviceLongPress.value = settings['button']['serviceLongPress']
       serviceTap.value = settings['button']['serviceTap']
@@ -746,6 +827,9 @@ function saveSettings() {
       backgroundColorEnd: bgColorEnd,
       useCustomButtonLabels: useCustomButtonLabels.value,
       buttonLabels: buttonLabels.value,
+      onIcon: customIcons.on,
+      offIcon: customIcons.off,
+      offlineIcon: customIcons.offline,
       useStateImagesForOnOffStates: useStateImagesForOnOffStates.value // determined by action ID (manifest)
     },
 
@@ -761,6 +845,52 @@ function saveSettings() {
   }
 
   $SD.saveSettings(settings)
+}
+
+// ── Custom icons (custom-icons action) ────────────────────────────────────
+function pickCustomIcon(slot) {
+  pendingIconSlot = slot
+  customIconFileInput.value?.click()
+}
+
+async function applyCustomIcon(slot, file, fileUrl) {
+  try {
+    customIcons[slot] = await loadIconAsDataUri(file, fileUrl)
+    customIconError.value = ''
+  } catch (e) {
+    customIconError.value = e.message
+  }
+}
+
+async function onCustomIconSelected(event) {
+  const input = event.target
+  const file = input.files && input.files[0]
+  const fileUrl = fileUrlFromInputValue(input.value)
+  if (!pendingIconSlot || (!file && !fileUrl)) return
+  await applyCustomIcon(pendingIconSlot, file, fileUrl)
+  input.value = ''
+}
+
+function onCustomIconDropped(slot, event) {
+  dragOverSlot.value = null
+  const dt = event.dataTransfer
+  if (!dt) return
+  const file = dt.files && dt.files[0]
+  const fileUrl = fileUrlFromDataTransfer(dt)
+  if (!file && !fileUrl) {
+    customIconError.value = 'Drop a local image file.'
+    return
+  }
+  applyCustomIcon(slot, file, fileUrl)
+}
+
+function onIconDragLeave(slot) {
+  if (dragOverSlot.value === slot) dragOverSlot.value = null
+}
+
+function clearCustomIcon(slot) {
+  customIcons[slot] = ''
+  customIconError.value = ''
 }
 
 // ── Debug report ──────────────────────────────────────────────────────────

--- a/src/components/PluginComponent.vue
+++ b/src/components/PluginComponent.vue
@@ -78,6 +78,9 @@ const renderGeneration = new Map()
 
 const activeStates = ref(defaultActiveStates)
 
+// Entity states rendered with the offline icon (custom-icons action).
+const OFFLINE_STATES = ['unavailable', 'unknown', 'none']
+
 const rotationTimeout = {}
 const rotationAmount = {}
 const rotationPercent = {}
@@ -440,12 +443,22 @@ async function updateContextState(currentContext, domain, stateObject, generatio
     if (renderingConfig.customTitle) {
       $SD.value.setTitle(currentContext, renderingConfig.customTitle)
     }
-    if (activeStates.value.includes(stateObject.state)) {
-      console.log('Setting state of ' + currentContext + ' to 1')
-      $SD.value.setState(currentContext, 1)
+    const display = contextSettings.display
+    const isOffline = OFFLINE_STATES.includes(stateObject.state)
+    const isActive = activeStates.value.includes(stateObject.state)
+    // Icons uploaded in the property inspector; offline falls back to off.
+    const customIcon = isOffline
+      ? display.offlineIcon || display.offIcon
+      : isActive
+        ? display.onIcon
+        : display.offIcon
+    if (customIcon) {
+      $SD.value.setImage(currentContext, customIcon)
     } else {
-      console.log('Setting state of ' + currentContext + ' to 0')
-      $SD.value.setState(currentContext, 0)
+      console.log('Setting state of ' + currentContext + ' to ' + (isActive ? 1 : 0))
+      $SD.value.setState(currentContext, isActive ? 1 : 0)
+      // Clear a possible custom-icon override so state images show again.
+      $SD.value.setImage(currentContext, null)
     }
   } else {
     if (renderingConfig.customTitle) {

--- a/src/modules/common/streamdeck.js
+++ b/src/modules/common/streamdeck.js
@@ -67,7 +67,9 @@ export class StreamDeck {
   }
 
   setImage(context, image) {
-    this.#send({ event: 'setImage', context, payload: { image, target: 0, state: 0 } })
+    // No `state` in the payload: the image then applies to every state of
+    // the action, so overrides also cover multi-state (custom icon) actions.
+    this.#send({ event: 'setImage', context, payload: { image, target: 0 } })
   }
 
   setFeedback(context, payload) {

--- a/src/modules/pi/iconLoader.js
+++ b/src/modules/pi/iconLoader.js
@@ -1,0 +1,114 @@
+// Loads user-selected images inside Stream Deck's restricted webview and
+// normalizes them to square PNG data URIs.
+
+const ICON_SIZE = 144
+
+function readBlobAsDataUri(blob) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(reader.result)
+    reader.onerror = () => reject(new Error(reader.error?.name ?? 'FileReader failed'))
+    reader.readAsDataURL(blob)
+  })
+}
+
+function loadImage(src) {
+  return new Promise((resolve, reject) => {
+    const img = new Image()
+    img.onload = () => resolve(img)
+    img.onerror = () => reject(new Error('could not decode image'))
+    img.src = src
+  })
+}
+
+function scaleToIconDataUri(img) {
+  const canvas = document.createElement('canvas')
+  canvas.width = ICON_SIZE
+  canvas.height = ICON_SIZE
+  const ctx = canvas.getContext('2d')
+  const scale = Math.min(ICON_SIZE / img.width, ICON_SIZE / img.height)
+  const w = img.width * scale
+  const h = img.height * scale
+  ctx.drawImage(img, (ICON_SIZE - w) / 2, (ICON_SIZE - h) / 2, w, h)
+  return canvas.toDataURL('image/png')
+}
+
+function xhrGetBlob(url) {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest()
+    xhr.open('GET', url)
+    xhr.responseType = 'blob'
+    // file:// responses report status 0 on success, so check the payload.
+    xhr.onload = () =>
+      xhr.response && xhr.response.size > 0
+        ? resolve(xhr.response)
+        : reject(new Error(`XHR empty response (status ${xhr.status})`))
+    xhr.onerror = () => reject(new Error(`XHR failed (status ${xhr.status})`))
+    xhr.send()
+  })
+}
+
+/**
+ * Extracts a file:// URL from a file input's value. Stream Deck's webview
+ * prefixes it with C:\fakepath\ but, unlike regular browsers, appends the
+ * real absolute path, URL-encoded.
+ * @returns {string|null}
+ */
+export function fileUrlFromInputValue(rawValue) {
+  if (!rawValue) return null
+  const path = decodeURIComponent(rawValue.replace(/^c:\\fakepath\\/i, ''))
+  if (!path.includes('/') && !path.includes('\\')) return null
+  return 'file:///' + path.replace(/\\/g, '/').replace(/^\/+/, '')
+}
+
+/**
+ * Extracts a file:// URL from a drop event's DataTransfer. Files dragged
+ * from the OS also arrive as a text/uri-list of file:// URLs.
+ * @returns {string|null}
+ */
+export function fileUrlFromDataTransfer(dataTransfer) {
+  const uriList = dataTransfer.getData('text/uri-list') || dataTransfer.getData('text/plain') || ''
+  return (
+    uriList
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find((line) => line && !line.startsWith('#') && /^file:/i.test(line)) ?? null
+  )
+}
+
+/**
+ * Loads an image from a File and/or file:// URL and returns it as a
+ * 144x144 PNG data URI. Tries several strategies because Stream Deck's
+ * webview blocks direct File reads but allows XHR to file:// URLs.
+ * @throws {Error} when no strategy succeeds
+ */
+export async function loadIconAsDataUri(file, fileUrl) {
+  const attempts = []
+  if (file) {
+    attempts.push(() => readBlobAsDataUri(file))
+    attempts.push(async () => URL.createObjectURL(file))
+  }
+  if (fileUrl) {
+    // fetch() rejects file:// URLs in Chromium, hence XHR.
+    attempts.push(async () => URL.createObjectURL(await xhrGetBlob(fileUrl)))
+    // Last resort; may taint the canvas but proves the file is readable.
+    attempts.push(async () => fileUrl)
+  }
+
+  const errors = []
+  for (const attempt of attempts) {
+    let src
+    try {
+      src = await attempt()
+      const img = await loadImage(src)
+      return scaleToIconDataUri(img)
+    } catch (e) {
+      errors.push(e.message)
+    } finally {
+      if (src && src.startsWith('blob:')) URL.revokeObjectURL(src)
+    }
+  }
+  throw new Error(
+    `Could not load image (${errors.join('; ')}) [source: ${fileUrl || file?.name || 'n/a'}]`
+  )
+}

--- a/src/scss/pi-design.scss
+++ b/src/scss/pi-design.scss
@@ -185,6 +185,102 @@ a {
   cursor: pointer;
 }
 
+// ── Custom icon tiles ────────────────────────────────────────────────────
+.pi-icon-row {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.pi-icon-slot {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.pi-icon-tile {
+  width: 56px;
+  height: 56px;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px dashed var(--pi-border-strong);
+  border-radius: var(--pi-radius);
+  background: var(--pi-bg-sunken);
+  cursor: pointer;
+  overflow: hidden;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
+
+  // Children must not intercept drag events, or dragleave fires when
+  // hovering them and the drop highlight flickers off.
+  img,
+  .pi-icon-plus {
+    pointer-events: none;
+  }
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+  }
+
+  &:hover {
+    border-color: var(--pi-accent);
+  }
+  &:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px var(--pi-accent);
+  }
+  &.pi-icon-tile-set {
+    border-style: solid;
+    border-color: var(--pi-border);
+  }
+  &.pi-icon-tile-drag {
+    border-color: var(--pi-accent);
+    box-shadow: 0 0 0 2px var(--pi-accent-dim);
+  }
+}
+
+.pi-icon-plus {
+  font-size: 22px;
+  line-height: 1;
+  color: var(--pi-text-muted);
+}
+
+.pi-icon-remove {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--pi-border-strong);
+  border-radius: 50%;
+  background: var(--pi-bg-raised);
+  color: var(--pi-text-secondary);
+  font-size: 12px;
+  line-height: 1;
+  cursor: pointer;
+
+  &:hover {
+    color: var(--pi-text-primary);
+    border-color: var(--pi-accent);
+  }
+}
+
+.pi-icon-label {
+  font-size: 11px;
+  color: var(--pi-text-secondary);
+}
+
 // ── Buttons ───────────────────────────────────────────────────────────────
 .pi-btn {
   display: inline-flex;


### PR DESCRIPTION
## Summary

Adds an "offline" visual state for the "Entity (custom icons)" action: when an entity is
`unavailable`/`unknown`, the button shows a dedicated offline icon, matching how Home
Assistant grays out unavailable entities. Closes discussion #425.

## Why not a third native state?

- The Stream Deck runtime accepts 3+ states (`setState(2)` works), but the app UI only
  renders two state dots, so users can never assign an image to a third state.
- User-dragged key images override plugin `setImage` calls, so overlaying an offline
  icon on top of native state images is silently ignored.

The plugin therefore has to own all state icons and render them itself.

## What changed

- **Property inspector**: new "Custom icons" section with three tiles (Off / On /
  Offline), set via click or drag-and-drop. Icons are downscaled to 144x144 PNG data
  URIs and stored in the action settings (`display.onIcon` / `offIcon` / `offlineIcon`,
  optional, no migration needed).
- **Plugin**: renders the matching icon via `setImage`; offline falls back to the off
  icon. Buttons without configured icons keep the native two-state behavior, so the
  change is fully backward compatible.
- **`iconLoader.js`** (new): image loading that works around the Stream Deck webview's
  blocked `File` reads by XHR-ing the real path exposed behind the `C:\fakepath\` prefix.
- **`streamdeck.js`**: `setImage` no longer pins `state: 0`, so images apply to all
  states of multi-state actions (no behavior change for single-state actions).

## Testing

Manually tested on Windows 11 / Stream Deck 6.9 against live Home Assistant: icons set
via click and drop, offline icon appears in real time when HA marks the entity
`unavailable` and clears on recovery, unconfigured buttons behave as before.