### PR TITLE
feat(icons): resolve custom icons through Home Assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Controls which icon is shown on the button:
 | **Home Assistant** | Uses the icon configured on the HA entity. Falls back to the plugin icon. |
 | **Hide** | No icon is shown. |
 
+With the [Custom Icons](https://github.com/thomasloven/hass-custom_icons) integration installed, identifiers such as `fa6-solid:shield` and `local:my-icon` are supported. Icons are cached and fall back to the plugin icon when unavailable. Custom SVGs can use `currentColor` to inherit the entity color; explicit colors are preserved.
+
 #### Visual Service Indicators *(Keypad only)*
 
 When enabled, small colored dots appear at the corners of the button to indicate which actions are configured (short press, long press, etc.).

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "streamdeck-homeassistant-vue",
       "version": "0.1.0",
       "dependencies": {
+        "@iconify/utils": "^3.1.4",
         "@mdi/font": "^7.4.47",
         "@mdi/js": "^7.4.47",
         "axios": "^1.16.1",
@@ -29,6 +30,19 @@
         "sass": "^1.93.3",
         "vite": "^7.2.2",
         "vitest": "^4.1.9"
+      }
+    },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -796,6 +810,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.4.tgz",
+      "integrity": "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "import-meta-resolve": "^4.2.0"
       }
     },
     "node_modules/@inquirer/checkbox": {
@@ -3561,6 +3592,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -4090,6 +4131,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-manager-detector": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.7.0.tgz",
+      "integrity": "sha512-xg1eHpwYL/D/HEdWw2goFZP6vV0FH7W+PZ5rFkGjdIDLtxq7EkzBUeT3m+lndYCt8wKbmofUu1MUdMCXkCk9ZQ==",
+      "license": "MIT"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4576,7 +4623,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
       "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test-watch": "vitest"
   },
   "dependencies": {
+    "@iconify/utils": "^3.1.4",
     "@mdi/font": "^7.4.47",
     "@mdi/js": "^7.4.47",
     "axios": "^1.16.1",

--- a/src/components/PluginComponent.vue
+++ b/src/components/PluginComponent.vue
@@ -9,12 +9,14 @@ import { LruCache } from '@/modules/common/lruCache'
 import { Homeassistant } from '@/modules/homeassistant/homeassistant'
 import { EntityConfigFactory } from '@/modules/plugin/entityConfigFactoryNg'
 import { SvgUtils, WIDTH, HEIGHT } from '@/modules/plugin/svgUtils'
+import { CustomIconResolver, applyCustomIcon } from '@/modules/plugin/customIconResolver'
 import { fetchRemoteYaml } from '@/modules/common/remoteConfig'
 import nunjucksEnv from '../modules/common/nunjucksEnv.js'
 import { onMounted, ref, shallowRef } from 'vue'
 import defaultActiveStates from '../../public/config/active-states.yml'
 
 let entityConfigFactory
+let customIconResolver
 const svgUtils = new SvgUtils()
 
 const imageCache = new LruCache(30)
@@ -228,6 +230,7 @@ function connectHomeAssistant() {
       onHAError,
       onHAClosed
     )
+    customIconResolver = new CustomIconResolver((set, icon) => $HA.value.getCustomIcon(set, icon))
   }
 }
 
@@ -237,6 +240,14 @@ let reconnectDelayMs = RECONNECT_BASE_DELAY_MS
 
 const onHAConnected = () => {
   reconnectDelayMs = RECONNECT_BASE_DELAY_MS
+  const homeAssistant = $HA.value
+  homeAssistant
+    .subscribeEvent('homeassistant_started', () => {
+      if ($HA.value !== homeAssistant) return
+      customIconResolver.reset()
+      homeAssistant.getStatesDebounced(entityStatesChanged)
+    })
+    .catch((error) => console.log(`Failed to subscribe to Home Assistant start: ${error}`))
   $HA.value.getStatesDebounced(entityStatesChanged)
   resubscribeEntities()
 }
@@ -402,6 +413,9 @@ async function updateContextState(currentContext, domain, stateObject, generatio
         ? entityConfigFactory.colors.active
         : entityConfigFactory.colors.neutral
   }
+
+  await applyCustomIcon(renderingConfig, customIconResolver)
+  if (isStale()) return
 
   const entityPicture = stateObject.attributes?.entity_picture
   if (entityPicture && globalSettings.value?.serverUrl) {

--- a/src/modules/homeassistant/homeassistant.js
+++ b/src/modules/homeassistant/homeassistant.js
@@ -84,6 +84,22 @@ export class Homeassistant {
     this._connection.sendMessagePromise({ type: 'get_services' }).then(callback)
   }
 
+  getCustomIcon(set, icon) {
+    if (!this._connection) {
+      return Promise.reject(new Error('Not connected to Home Assistant'))
+    }
+    return this._connection.sendMessagePromise({
+      type: 'custom_icons/icon',
+      set,
+      icon
+    })
+  }
+
+  subscribeEvent(eventType, callback) {
+    if (!this._connection) return Promise.resolve(null)
+    return this._connection.subscribeEvents(callback, eventType)
+  }
+
   async subscribeEntitiesChanged(entityIds, callback) {
     if (!this._connection) return null
     try {

--- a/src/modules/plugin/customIconResolver.js
+++ b/src/modules/plugin/customIconResolver.js
@@ -1,0 +1,109 @@
+import { iconToSVG } from '@iconify/utils'
+import { LruCache } from '../common/lruCache.js'
+
+export function parseIcon(identifier) {
+  if (typeof identifier !== 'string') return null
+
+  const [value] = identifier.trim().split('#')
+  const separator = value.indexOf(':')
+  if (separator <= 0 || separator === value.length - 1) return null
+
+  const prefix = value.substring(0, separator)
+  if (prefix === 'mdi' || prefix === 'hue') return null
+
+  return {
+    set: prefix,
+    icon: value.substring(separator + 1)
+  }
+}
+
+export function renderIcon(iconData) {
+  if (!iconData || typeof iconData !== 'object') return null
+
+  if (iconData.renderer === 'iconify') {
+    try {
+      const rendered = iconToSVG(iconData)
+      return normalizeIcon(rendered.body, rendered.viewBox)
+    } catch {
+      return null
+    }
+  }
+
+  return normalizeIcon(iconData.body || renderPaths(iconData), iconData.viewBox)
+}
+
+export class CustomIconResolver {
+  constructor(loadIcon) {
+    this._loadIcon = loadIcon
+    this._generation = 0
+    this.reset()
+  }
+
+  reset() {
+    this._generation += 1
+    this._cache = new LruCache(100)
+    this._available = true
+  }
+
+  resolve(identifier) {
+    const parsed = parseIcon(identifier)
+    if (!parsed || !this._available) return Promise.resolve(null)
+
+    const key = `${parsed.set}:${parsed.icon}`
+    const cached = this._cache.get(key)
+    if (cached) return cached
+
+    const generation = this._generation
+    const request = this._loadIcon(parsed.set, parsed.icon)
+      .then(renderIcon)
+      .catch((error) => {
+        if (error?.code === 'unknown_command' && generation === this._generation) {
+          this._available = false
+        }
+        return null
+      })
+
+    this._cache.set(key, request)
+    return request
+  }
+}
+
+export async function applyCustomIcon(renderingConfig, resolver) {
+  if (!resolver || !parseIcon(renderingConfig.icon)) return
+
+  renderingConfig.customIcon = await resolver.resolve(renderingConfig.icon)
+  if (renderingConfig.customIcon) return
+
+  renderingConfig.icon = renderingConfig.fallbackIcon ?? null
+}
+
+function normalizeIcon(body, viewBox) {
+  if (typeof body !== 'string' || !body.trim()) return null
+
+  const values = Array.isArray(viewBox)
+    ? viewBox.map(Number)
+    : String(viewBox ?? '')
+        .trim()
+        .split(/[\s,]+/)
+        .map(Number)
+
+  if (
+    values.length !== 4 ||
+    values.some((value) => !Number.isFinite(value)) ||
+    values[2] <= 0 ||
+    values[3] <= 0
+  ) {
+    return null
+  }
+
+  return {
+    body: body.trim(),
+    viewBox: values.join(' ')
+  }
+}
+
+function renderPaths(iconData) {
+  const primary = iconData.path ? `<path d="${iconData.path}"/>` : ''
+  const secondary = iconData.path2 ? `<path d="${iconData.path2}" opacity=".4"/>` : ''
+  return `${primary}${secondary}`
+}

--- a/src/modules/plugin/customIconResolver.test.js
+++ b/src/modules/plugin/customIconResolver.test.js
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi } from 'vitest'
+import { Homeassistant } from '../homeassistant/homeassistant.js'
+import { EntityConfigFactory } from './entityConfigFactoryNg.js'
+import { CustomIconResolver, applyCustomIcon, parseIcon, renderIcon } from './customIconResolver.js'
+
+const iconData = {
+  body: '<path d="M0 0h32v16z"/>',
+  viewBox: [0, 0, 32, 16]
+}
+
+describe('custom icon data', () => {
+  it('parses custom identifiers but leaves built-in icons local', () => {
+    expect(parseIcon('mdi:lightbulb')).toBeNull()
+    expect(parseIcon('hue:adore')).toBeNull()
+    expect(parseIcon('lightbulb')).toBeNull()
+    expect(parseIcon('custom-set:icon#variant')).toEqual({ set: 'custom-set', icon: 'icon' })
+  })
+
+  it('handles SVG bodies and path-only responses', () => {
+    expect(renderIcon(iconData)).toEqual({ body: iconData.body, viewBox: '0 0 32 16' })
+    expect(
+      renderIcon({ path: 'M0 0h16v16z', path2: 'M4 4h8v8z', viewBox: [0, 0, 16, 16] })
+    ).toEqual({
+      body: '<path d="M0 0h16v16z"/><path d="M4 4h8v8z" opacity=".4"/>',
+      viewBox: '0 0 16 16'
+    })
+    expect(renderIcon({ body: '<path/>', viewBox: [0, 0, 0, 16] })).toBeNull()
+  })
+
+  it('applies Iconify rotation and flip metadata', () => {
+    const icon = renderIcon({
+      renderer: 'iconify',
+      body: '<path d="M0 0h16v8z"/>',
+      width: 16,
+      height: 8,
+      rotate: 1,
+      hFlip: true
+    })
+
+    expect(icon.viewBox).toBe('0 0 8 16')
+    expect(icon.body).toContain('<g transform=')
+  })
+})
+
+describe('CustomIconResolver', () => {
+  it('uses the Home Assistant command once for concurrent and repeated requests', async () => {
+    const sendMessagePromise = vi.fn(async () => iconData)
+    const homeAssistant = Object.create(Homeassistant.prototype)
+    homeAssistant._connection = { sendMessagePromise }
+    const resolver = new CustomIconResolver((set, icon) => homeAssistant.getCustomIcon(set, icon))
+
+    await Promise.all([resolver.resolve('custom-set:icon'), resolver.resolve('custom-set:icon')])
+    await resolver.resolve('custom-set:icon')
+
+    expect(sendMessagePromise).toHaveBeenCalledOnce()
+    expect(sendMessagePromise).toHaveBeenCalledWith({
+      type: 'custom_icons/icon',
+      set: 'custom-set',
+      icon: 'icon'
+    })
+  })
+
+  it('caches failures and retries after a reset', async () => {
+    const missingIcon = vi.fn(async () => {
+      throw { code: 'not_found' }
+    })
+    const missingResolver = new CustomIconResolver(missingIcon)
+    await missingResolver.resolve('custom-set:missing')
+    await missingResolver.resolve('custom-set:missing')
+    expect(missingIcon).toHaveBeenCalledOnce()
+
+    const unavailable = vi.fn(async () => {
+      throw { code: 'unknown_command' }
+    })
+    const unavailableResolver = new CustomIconResolver(unavailable)
+    await unavailableResolver.resolve('custom-set:first')
+    await unavailableResolver.resolve('custom-set:second')
+    expect(unavailable).toHaveBeenCalledOnce()
+
+    unavailable.mockResolvedValue(iconData)
+    unavailableResolver.reset()
+    expect(await unavailableResolver.resolve('custom-set:second')).not.toBeNull()
+    expect(unavailable).toHaveBeenCalledTimes(2)
+  })
+
+  it('subscribes to Home Assistant lifecycle events', async () => {
+    const callback = vi.fn()
+    const subscribeEvents = vi.fn(async () => vi.fn())
+    const homeAssistant = Object.create(Homeassistant.prototype)
+    homeAssistant._connection = { subscribeEvents }
+
+    await homeAssistant.subscribeEvent('homeassistant_started', callback)
+
+    expect(subscribeEvents).toHaveBeenCalledWith(callback, 'homeassistant_started')
+  })
+
+  it('ignores unavailable results from before a reset', async () => {
+    let rejectRequest
+    const loadIcon = vi.fn(
+      () =>
+        new Promise((_, reject) => {
+          rejectRequest = reject
+        })
+    )
+    const resolver = new CustomIconResolver(loadIcon)
+    const staleRequest = resolver.resolve('custom-set:first')
+
+    resolver.reset()
+    rejectRequest({ code: 'unknown_command' })
+    await staleRequest
+    loadIcon.mockResolvedValue(iconData)
+
+    expect(await resolver.resolve('custom-set:second')).not.toBeNull()
+    expect(loadIcon).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('applyCustomIcon', () => {
+  it('uses a resolved icon and falls back to the plugin icon when missing', async () => {
+    const resolvedIcon = renderIcon(iconData)
+    const renderingConfig = { icon: 'custom-set:icon' }
+    await applyCustomIcon(renderingConfig, { resolve: vi.fn(async () => resolvedIcon) })
+    expect(renderingConfig.customIcon).toEqual(resolvedIcon)
+
+    const factory = new EntityConfigFactory()
+    factory.getConfig = () => ({ icon: 'mdi:lightbulb', labelTemplates: [] })
+    const fallbackConfig = factory.determineConfig(
+      'light',
+      { state: 'on', attributes: { icon: 'custom-set:missing' } },
+      { iconSettings: 'PREFER_HA' }
+    )
+    await applyCustomIcon(fallbackConfig, { resolve: vi.fn(async () => null) })
+    expect(fallbackConfig.icon).toBe('mdi:lightbulb')
+  })
+
+  it('does not request hidden or built-in icons', async () => {
+    const resolver = { resolve: vi.fn() }
+    await applyCustomIcon({ icon: null }, resolver)
+    await applyCustomIcon({ icon: 'mdi:lightbulb' }, resolver)
+    expect(resolver.resolve).not.toHaveBeenCalled()
+  })
+})

--- a/src/modules/plugin/entityConfigFactoryNg.js
+++ b/src/modules/plugin/entityConfigFactoryNg.js
@@ -48,6 +48,9 @@ export class EntityConfigFactory {
       (!renderingConfig.icon || displaySettings.iconSettings === 'PREFER_HA')
     ) {
       // Use icon from home-assistant, if no default or preferred
+      if (renderingConfig.icon && renderingConfig.icon !== attributes.icon) {
+        renderingConfig.fallbackIcon = renderingConfig.icon
+      }
       renderingConfig.icon = attributes.icon
     }
     let rgbColor = attributes.rgb_color

--- a/src/modules/plugin/svgUtils.js
+++ b/src/modules/plugin/svgUtils.js
@@ -16,6 +16,7 @@ export class SvgUtils {
     return this.#generateButtonSVG(
       labels,
       renderingConfig.icon,
+      renderingConfig.customIcon,
       renderingConfig.color,
       renderingConfig.isAction,
       renderingConfig.isMultiAction,
@@ -34,6 +35,7 @@ export class SvgUtils {
   #generateButtonSVG(
     labels,
     mdiIconName,
+    customIcon,
     iconColor,
     isAction = false,
     isMultiAction = false,
@@ -61,10 +63,10 @@ export class SvgUtils {
         `<rect x="0" y="0" width="${WIDTH}" height="${HEIGHT}" fill="rgba(0,0,0,${BG_OVERLAY_OPACITY})"/>`
       : ''
 
-    const iconPath = this.#getIconPath(mdiIconName)
+    const iconPath = customIcon ? null : this.#getIconPath(mdiIconName)
 
     let iconTransform, maxLines, labelIndexOffset
-    if (!iconPath || iconLayout === 'FULL') {
+    if ((!customIcon && !iconPath) || iconLayout === 'FULL') {
       iconTransform = `translate(0, 0) scale(12)`
       maxLines = 4
       labelIndexOffset = 0
@@ -78,9 +80,12 @@ export class SvgUtils {
       labelIndexOffset = 2
     }
 
-    const iconSvg = iconPath
-      ? `<g transform="${iconTransform}"><path d="${iconPath}" fill="${iconColor ?? '#FFF'}"/></g>`
-      : ''
+    let iconSvg = ''
+    if (customIcon) {
+      iconSvg = this.#renderCustomIcon(customIcon, iconColor, iconTransform)
+    } else if (iconPath) {
+      iconSvg = `<g transform="${iconTransform}"><path d="${iconPath}" fill="${iconColor ?? '#FFF'}"/></g>`
+    }
 
     const indicatorColor = isMultiAction ? '#3e89ff' : '#62ff65'
     const indicator = isAction
@@ -108,6 +113,11 @@ export class SvgUtils {
       })
 
     return `<svg xmlns="http://www.w3.org/2000/svg" width="${WIDTH}" height="${HEIGHT}" viewBox="0 0 ${WIDTH} ${HEIGHT}">${defsSvg}${bgColorSvg}${backgroundSvg}${iconSvg}${indicator}${textLines.join('')}</svg>`
+  }
+
+  #renderCustomIcon(customIcon, iconColor, transform) {
+    const color = iconColor ?? '#FFF'
+    return `<g transform="${transform}"><svg width="24" height="24" viewBox="${customIcon.viewBox}" preserveAspectRatio="xMidYMid meet" fill="${color}" color="${color}">${customIcon.body}</svg></g>`
   }
 
   #getIconPath(iconName) {

--- a/src/modules/plugin/svgUtils.test.js
+++ b/src/modules/plugin/svgUtils.test.js
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { SvgUtils } from './svgUtils.js'
+
+const stateObject = { state: 'on', attributes: {} }
+const customIcon = {
+  body: '<path d="M0 0h32v16z"/><path fill="currentColor" d="M2 2h12v12z"/><path fill="#ff0000" d="M4 4h8v8z"/>',
+  viewBox: '0 0 32 16'
+}
+
+function render(config) {
+  return new SvgUtils().renderButtonSVG(
+    {
+      labelTemplates: [],
+      color: '#123456',
+      ...config
+    },
+    stateObject
+  )
+}
+
+describe('SvgUtils custom icon rendering', () => {
+  it.each([
+    ['STANDARD', 'translate(72, 0) scale(6)'],
+    ['BOTTOM', 'translate(72, 144) scale(6)'],
+    ['FULL', 'translate(0, 0) scale(12)']
+  ])('renders the %s layout', (iconLayout, transform) => {
+    const svg = render({ icon: 'local:crest', customIcon, iconLayout })
+
+    expect(svg).toContain(`<g transform="${transform}"><svg width="24" height="24"`)
+    expect(svg).toContain('viewBox="0 0 32 16"')
+  })
+
+  it('provides inherited status color without replacing explicit colors', () => {
+    const svg = render({ icon: 'local:crest', customIcon })
+
+    expect(svg).toContain('fill="#123456" color="#123456"')
+    expect(svg).toContain('fill="currentColor"')
+    expect(svg).toContain('fill="#ff0000"')
+  })
+})
+
+describe('SvgUtils built-in icon regression', () => {
+  it.each(['mdi:lightbulb', 'hue:adore'])('still renders %s locally', (icon) => {
+    const svg = render({ icon })
+
+    expect(svg).toContain('<g transform="translate(72, 0) scale(6)"><path d="')
+    expect(svg).toContain('fill="#123456"')
+  })
+})


### PR DESCRIPTION
Home Assistant can provide additional icon sets through the optional [`custom_icons`](https://github.com/thomasloven/hass-custom_icons) integration, but these icons could not previously be rendered by the Stream Deck plugin.

I wanted to manage custom icons in Home Assistant and use the same icon and entity color on Stream Deck, without configuring or uploading an SVG for every individual key.

This change:

- resolves non-MDI/Hue identifiers such as `fa6-solid:shield` and `local:my-icon` through Home Assistant
- uses the existing "prefer Home Assistant icon" setting
- caches resolved icons and preserves `currentColor` and explicit SVG colors
- falls back to the normal plugin icon when `custom_icons` is unavailable or an icon is missing
- refreshes custom icon availability and caches after Home Assistant finishes restarting
- leaves existing MDI, Hue, hidden-icon, layout, and status-color behavior unchanged

Tested with local SVGs and Font Awesome icons on Keypad and Encoder, including live entity coloring and a Home Assistant restart without restarting Stream Deck.

Validation: `npm test`, `npm run lint`, `npm run format`, `npm run build`, and `npm run validate`.

Related: #235, #410, #420

## Screenshot

<img width="187" height="264" alt="pr-screenshot" src="https://github.com/user-attachments/assets/f9c6741d-5c7b-4364-a249-2843e73dba44" />

Icon artwork from different sets can have different visual bounds, so its apparent size may vary. Icon sizing remains unchanged in this PR; optional per-key scaling can be considered separately.
